### PR TITLE
:wrench: Nuxt compat date

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -5,8 +5,10 @@ export default defineNuxtConfig({
       title: ".POAP",
     },
   },
+
   css: ["~/assets/css/main.css"],
   devtools: { enabled: true },
+
   modules: [
     "@nuxtjs/tailwindcss",
     "@pinia/nuxt",
@@ -17,15 +19,19 @@ export default defineNuxtConfig({
     "@nuxtjs/color-mode",
     "@vue-final-modal/nuxt",
   ],
+
   runtimeConfig: {
     apiUrl: "",
     public: {
       appUrl: "",
     },
   },
+
   googleFonts: {
     families: {
       Unbounded: true,
     },
   },
+
+  compatibilityDate: "2024-09-20",
 });


### PR DESCRIPTION
From CLI:

[6:23:21 PM] ℹ Nuxt now supports pinning the behavior of provider and deployment presets with a compatibility date. We recommend you specify a compatibilityDate in your nuxt.config file, or set an environment variable, such as COMPATIBILITY_DATE=2024-09-20.

✔ Do you want to update your nuxt.config to set compatibilityDate: '2024-09-20'?
Yes
