### PR TITLE
fix: wallet not correctly disconnecting

### DIFF
--- a/components/modals/connect-modal.vue
+++ b/components/modals/connect-modal.vue
@@ -147,7 +147,8 @@ const saveAndClose = () => {
 
 const disconnect = () => {
   accountStore.disconnect();
-  localStorage.removeItem("account");
+  localStorage.removeItem("account-address");
+  localStorage.removeItem("account-wallet");
   emit("confirm");
 };
 </script>


### PR DESCRIPTION
### Context

- closes  #207 

### Problem
The  `disconnect()` function was trying to remove `localStorage.removeItem("account")`, but this key was never set. The actual keys used by  `saveAndClose()`  are `account-address` and `account-wallet`

### Solution
Updated  `disconnect()`  to remove the correct localStorage keys
