### PR TITLE
feat(claim): customize success modal

### DIFF
--- a/app/components/claim/ClaimSuccess.vue
+++ b/app/components/claim/ClaimSuccess.vue
@@ -1,29 +1,52 @@
 <template>
   <template v-if="sn">
-    <a :href="url" class="block w-full">
+    <a v-if="!previewMode" :href="url" class="block w-full">
       <dot-button class="w-full" variant="primary" size="large">
-        {{ t("claim.seeInGallery", { name: memoName ?? "MEMO" }) }}
+        {{ primaryCtaLabel }}
       </dot-button>
     </a>
+    <div v-else class="block w-full">
+      <dot-button class="w-full" variant="primary" size="large">
+        {{ primaryCtaLabel }}
+      </dot-button>
+    </div>
     <div class="flex w-full flex-col items-center gap-2">
-      <small class="dark:text-white">{{ t("claim.wantToShare") }}</small>
+      <small class="dark:text-white">{{ shareHeading }}</small>
       <span class="mb-10 flex gap-2">
-        <div class="flex cursor-pointer items-center gap-2" @click="shareOnTelegram(shareMessage, url)">
+        <button
+          type="button"
+          class="flex items-center gap-2"
+          :class="previewMode ? 'cursor-not-allowed opacity-50' : 'cursor-pointer'"
+          :disabled="previewMode"
+          :aria-disabled="previewMode"
+          :tabindex="previewMode ? -1 : 0"
+          @click="handleShareOnTelegram"
+        >
           <div class="overflow-hidden rounded-full border border-white">
             <img src="/socials/telegram.webp" alt="Telegram" class="size-10" />
           </div>
-        </div>
-        <div class="flex cursor-pointer items-center gap-2" @click="shareOnX(shareMessage, url)">
+        </button>
+        <button
+          type="button"
+          class="flex items-center gap-2"
+          :class="previewMode ? 'cursor-not-allowed opacity-50' : 'cursor-pointer'"
+          :disabled="previewMode"
+          :aria-disabled="previewMode"
+          :tabindex="previewMode ? -1 : 0"
+          @click="handleShareOnX"
+        >
           <div class="overflow-hidden rounded-full border border-white">
             <img src="/socials/x.webp" alt="X" class="size-10" />
           </div>
-        </div>
+        </button>
       </span>
     </div>
   </template>
 </template>
 
 <script setup lang="ts">
+import type { MemoCustomize } from "~/types/memo";
+
 const SHARE_MESSAGE = "I just claimed a new MEMO on dotmemo.xyz! 🎉";
 
 const { shareOnTelegram, shareOnX } = useSocials();
@@ -36,12 +59,37 @@ const props = withDefaults(
     sn: string | undefined;
     memoName?: string;
     shareMessage?: string;
+    customization?: MemoCustomize;
+    previewMode?: boolean;
   }>(),
   {
     shareMessage: SHARE_MESSAGE,
     memoName: "",
+    customization: undefined,
+    previewMode: false,
   },
 );
 
+const successCustomization = computed(() => props.customization?.success ?? {});
+const primaryCtaLabel = computed(() => {
+  return successCustomization.value.primaryCtaLabel || t("claim.seeInGallery", { name: props.memoName || "MEMO" });
+});
+const shareHeading = computed(() => successCustomization.value.shareHeading || t("claim.wantToShare"));
 const url = computed(() => `https://chaotic.art/${props.chain}/gallery/${props.collection}-${props.sn}`);
+
+const handleShareOnTelegram = () => {
+  if (props.previewMode) {
+    return;
+  }
+
+  shareOnTelegram(props.shareMessage, url.value);
+};
+
+const handleShareOnX = () => {
+  if (props.previewMode) {
+    return;
+  }
+
+  shareOnX(props.shareMessage, url.value);
+};
 </script>

--- a/app/components/claim/ClaimSuccess.vue
+++ b/app/components/claim/ClaimSuccess.vue
@@ -58,12 +58,10 @@ const props = withDefaults(
     chain: string;
     sn: string | undefined;
     memoName?: string;
-    shareMessage?: string;
     customization?: MemoCustomize;
     previewMode?: boolean;
   }>(),
   {
-    shareMessage: SHARE_MESSAGE,
     memoName: "",
     customization: undefined,
     previewMode: false,
@@ -82,7 +80,7 @@ const handleShareOnTelegram = () => {
     return;
   }
 
-  shareOnTelegram(props.shareMessage, url.value);
+  shareOnTelegram(SHARE_MESSAGE, url.value);
 };
 
 const handleShareOnX = () => {
@@ -90,6 +88,6 @@ const handleShareOnX = () => {
     return;
   }
 
-  shareOnX(props.shareMessage, url.value);
+  shareOnX(SHARE_MESSAGE, url.value);
 };
 </script>

--- a/app/components/claim/ClaimSuccessModalContent.vue
+++ b/app/components/claim/ClaimSuccessModalContent.vue
@@ -1,0 +1,57 @@
+<template>
+  <div class="flex w-full flex-col items-center gap-6">
+    <image-preview :src="successImage" />
+
+    <div class="flex flex-col items-center gap-3 text-center">
+      <h2 class="text-2xl font-medium text-text-primary">
+        {{ successTitle }}
+      </h2>
+      <p v-if="successDescription" class="max-w-md text-sm text-text-secondary">
+        {{ successDescription }}
+      </p>
+    </div>
+
+    <ClaimSuccess
+      :sn="sn"
+      :collection="collection"
+      :chain="chain"
+      :memo-name="memoName"
+      :customization="customization"
+      :preview-mode="previewMode"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { MemoCustomize } from "~/types/memo";
+
+const props = withDefaults(
+  defineProps<{
+    collection: string;
+    chain: string;
+    sn?: string;
+    memoName?: string;
+    memoImage?: string;
+    customization?: MemoCustomize;
+    previewMode?: boolean;
+  }>(),
+  {
+    memoName: "",
+    memoImage: "",
+    sn: undefined,
+    customization: undefined,
+    previewMode: false,
+  },
+);
+
+const { t } = useI18n();
+
+const successCustomization = computed(() => props.customization?.success ?? {});
+
+const successImage = computed(() => {
+  return successCustomization.value.image || props.customization?.image || props.memoImage;
+});
+
+const successTitle = computed(() => successCustomization.value.title || t("claim.success"));
+const successDescription = computed(() => successCustomization.value.description || "");
+</script>

--- a/app/components/manage/drop-customize-claim-page.vue
+++ b/app/components/manage/drop-customize-claim-page.vue
@@ -1,6 +1,15 @@
 <template>
-  <div class="grid grid-cols-1 gap-x-8 md:grid-cols-3">
-    <div class="flex w-full flex-col justify-center gap-8 md:w-auto">
+  <ManageDropCustomizeLayout
+    :button-label="buttonLabel"
+    :disabled="loading || !meta.valid || !!imageError || !!submitImageError"
+    :is-valid="meta.valid"
+    :update-error="updateError"
+    :submit-image-error="submitImageError"
+    :preview-title="$t('manage.customize.preview')"
+    :preview-hint="$t('manage.customize.previewHint')"
+    @save="save"
+  >
+    <template #form>
       <div class="flex flex-col gap-4">
         <span class="flex items-center gap-2">
           <h2 class="text-xl font-medium">
@@ -138,31 +147,12 @@
           <b class="text-base font-normal !text-text-secondary">21:1</b>
         </div>
       </div>
+    </template>
 
-      <div class="flex w-full flex-col items-center gap-2">
-        <dot-button :disabled="loading || !meta.valid" class="w-full" @click="save">
-          {{ buttonLabel }}
-        </dot-button>
-        <p v-if="updateError" class="text-center text-sm !text-red-500">{{ updateError }}</p>
-        <p v-else-if="submitImageError" class="text-center text-sm !text-yellow-500">
-          {{ submitImageError }}
-        </p>
-        <p v-else-if="!meta.valid" class="text-center text-sm !text-yellow-500">
-          {{ $t("manage.customize.validationRequired") }}
-        </p>
-      </div>
-    </div>
-
-    <div class="col-span-2 flex flex-col gap-8">
-      <div class="flex flex-col items-center gap-4">
-        <div class="flex w-[450px] justify-between">
-          <h2 class="text-xl font-medium">{{ $t("manage.customize.preview") }}</h2>
-          <p class="text-base font-normal !text-text-secondary">{{ $t("manage.customize.previewHint") }}</p>
-        </div>
-      </div>
+    <template #preview>
       <manage-drop-preview :data="editedData" />
-    </div>
-  </div>
+    </template>
+  </ManageDropCustomizeLayout>
 </template>
 
 <script lang="ts" setup>

--- a/app/components/manage/drop-customize-claim-page.vue
+++ b/app/components/manage/drop-customize-claim-page.vue
@@ -315,15 +315,15 @@ const {
 
 const buildClaimPageCustomize = (): MemoClaimPageCustomize => ({
   image: isCustomPreview.value ? image.value || undefined : undefined,
-  heading: heading.value || undefined,
-  subheading: subheading.value || undefined,
-  claimText: claimText.value || undefined,
-  telegram: parseUsername(telegram.value) || undefined,
-  instagram: parseUsername(instagram.value) || undefined,
-  twitter: parseUsername(twitter.value) || undefined,
+  heading: heading.value?.trim() || undefined,
+  subheading: subheading.value?.trim() || undefined,
+  claimText: claimText.value?.trim() || undefined,
+  telegram: normalizeHandle(telegram.value) || undefined,
+  instagram: normalizeHandle(instagram.value) || undefined,
+  twitter: normalizeHandle(twitter.value) || undefined,
   website: normalizeUrl(website.value) || undefined,
   darkMode: darkMode.value,
-  accentColor: accentColor.value || undefined,
+  accentColor: accentColor.value?.trim() || undefined,
 });
 
 const editedData = computed<Memo>(() => {

--- a/app/components/manage/drop-customize-claim-page.vue
+++ b/app/components/manage/drop-customize-claim-page.vue
@@ -1,0 +1,365 @@
+<template>
+  <div class="grid grid-cols-1 gap-x-8 md:grid-cols-3">
+    <div class="flex w-full flex-col justify-center gap-8 md:w-auto">
+      <div class="flex flex-col gap-4">
+        <span class="flex items-center gap-2">
+          <h2 class="text-xl font-medium">
+            {{ $t("manage.customize.title") }}
+          </h2>
+          <div
+            class="group relative flex h-[20px] w-[20px] cursor-default items-center justify-center rounded-full border-2 border-text-secondary px-2"
+          >
+            <span class="text-[12px] text-text-secondary">?</span>
+            <span
+              class="pointer-events-none absolute bottom-5 right-0 z-50 mt-2 w-64 rounded-lg border border-border-default bg-surface-card px-3 py-2 opacity-0 shadow-xl transition-opacity group-hover:opacity-100 dark:bg-white"
+            >
+              {{ $t("manage.customize.titleHint") }}
+            </span>
+          </div>
+        </span>
+
+        <div class="flex flex-col">
+          <div class="flex w-full items-center justify-between">
+            <b class="text-base font-normal">{{ $t("manage.customize.customPreviewImage") }}</b>
+            <dot-switch v-model="isCustomPreview" />
+          </div>
+          <p class="!text-sm !font-normal !text-text-secondary">
+            {{ $t("manage.customize.customPreviewImageHint") }}
+          </p>
+        </div>
+        <div v-if="isCustomPreview" class="flex flex-col gap-2">
+          <dot-image-input v-model="customImageFile" :preview-src="uploaderPreviewSrc" />
+          <p v-if="imageError" class="text-sm font-normal !text-red-500">
+            {{ imageError }}
+          </p>
+          <p class="text-sm font-normal !text-text-secondary">
+            {{ $t("manage.customize.customPreviewImageRequirements") }}
+          </p>
+        </div>
+      </div>
+
+      <div class="flex flex-col gap-[42px]">
+        <h2 class="text-xl font-medium">{{ $t("manage.customize.textContent") }}</h2>
+        <div class="flex flex-col gap-[16px]">
+          <div class="flex w-full items-center justify-between">
+            <b class="text-base !font-normal">{{ $t("manage.customize.heading") }}</b>
+            <p class="text-xs font-normal" :class="{ '!text-red-500': errors.heading }">
+              {{ heading?.length ?? 0 }}/40
+            </p>
+          </div>
+          <dot-text-input v-model="heading" :placeholder="$t('common.text')" maxlength="40" />
+          <p v-if="errors.heading" class="mt-1 text-xs !text-red-500">
+            {{ errors.heading }}
+          </p>
+        </div>
+        <div class="flex flex-col gap-[16px]">
+          <div class="flex w-full items-center justify-between">
+            <span class="flex items-center gap-2">
+              <b class="text-base !font-normal">{{ $t("manage.customize.subheading") }}</b>
+              <p class="text-xs !font-normal !text-text-secondary">({{ $t("common.optional") }})</p>
+            </span>
+            <p class="text-xs font-normal" :class="{ '!text-red-500': errors.subheading }">
+              {{ subheading?.length ?? 0 }}/300
+            </p>
+          </div>
+          <dot-text-area v-model="subheading" :placeholder="$t('common.text')" maxlength="300" />
+          <p v-if="errors.subheading" class="mt-1 text-xs !text-red-500">
+            {{ errors.subheading }}
+          </p>
+        </div>
+        <div class="flex flex-col gap-[16px]">
+          <div class="flex w-full items-center justify-between">
+            <b class="text-base !font-normal">{{ $t("manage.customize.buttonText") }}</b>
+            <p class="text-xs font-normal" :class="{ '!text-red-500': errors.claimText }">
+              {{ claimText?.length ?? 0 }}/40
+            </p>
+          </div>
+          <dot-text-input v-model="claimText" :placeholder="$t('common.claim')" maxlength="40" />
+          <p v-if="errors.claimText" class="mt-1 text-xs !text-red-500">
+            {{ errors.claimText }}
+          </p>
+        </div>
+      </div>
+
+      <div class="flex flex-col gap-4">
+        <h2 class="text-xl font-medium">{{ $t("manage.customize.socials") }}</h2>
+        <p class="!text-text-secondary">{{ $t("manage.customize.socialsHint") }}</p>
+        <dot-text-input v-model="telegram" placeholder="Telegram">
+          <template #prefix>
+            <Icon name="mdi:telegram" class="text-text-primary" />
+          </template>
+        </dot-text-input>
+        <p v-if="errors.telegram" class="mt-1 text-xs !text-red-500">
+          {{ errors.telegram }}
+        </p>
+        <dot-text-input v-model="instagram" placeholder="@instagram">
+          <template #prefix>
+            <Icon name="mdi:instagram" class="text-text-primary" />
+          </template>
+        </dot-text-input>
+        <p v-if="errors.instagram" class="mt-1 text-xs !text-red-500">
+          {{ errors.instagram }}
+        </p>
+        <dot-text-input v-model="twitter" placeholder="@x">
+          <template #prefix>
+            <Icon name="simple-icons:x" class="text-text-primary" />
+          </template>
+        </dot-text-input>
+        <p v-if="errors.twitter" class="mt-1 text-xs !text-red-500">
+          {{ errors.twitter }}
+        </p>
+        <dot-text-input v-model="website" placeholder="website.com">
+          <template #prefix>
+            <Icon name="mdi:web" class="text-text-primary" />
+          </template>
+        </dot-text-input>
+        <p v-if="errors.website" class="mt-1 text-xs !text-red-500">
+          {{ errors.website }}
+        </p>
+      </div>
+
+      <div class="flex flex-col gap-4">
+        <h2 class="text-xl font-medium">{{ $t("manage.customize.colors") }}</h2>
+        <p class="!text-text-secondary">{{ $t("manage.customize.colorsHint") }}</p>
+
+        <div class="flex w-full items-center justify-between">
+          <b class="text-base font-normal">{{ $t("manage.customize.darkMode") }}</b>
+          <dot-switch v-model="darkMode" />
+        </div>
+        <div class="flex flex-col gap-1">
+          <b class="text-base font-normal">{{ $t("manage.customize.accentColor") }}</b>
+          <dot-color-picker v-model="accentColor" />
+          <p v-if="errors.accentColor" class="mt-1 text-xs !text-red-500">
+            {{ errors.accentColor }}
+          </p>
+        </div>
+        <div class="flex justify-between">
+          <b class="text-base font-normal !text-text-secondary">{{ $t("manage.customize.contrastCheck") }}</b>
+          <b class="text-base font-normal !text-text-secondary">21:1</b>
+        </div>
+      </div>
+
+      <div class="flex w-full flex-col items-center gap-2">
+        <dot-button :disabled="loading || !meta.valid" class="w-full" @click="save">
+          {{ buttonLabel }}
+        </dot-button>
+        <p v-if="updateError" class="text-center text-sm !text-red-500">{{ updateError }}</p>
+        <p v-else-if="submitImageError" class="text-center text-sm !text-yellow-500">
+          {{ submitImageError }}
+        </p>
+        <p v-else-if="!meta.valid" class="text-center text-sm !text-yellow-500">
+          {{ $t("manage.customize.validationRequired") }}
+        </p>
+      </div>
+    </div>
+
+    <div class="col-span-2 flex flex-col gap-8">
+      <div class="flex flex-col items-center gap-4">
+        <div class="flex w-[450px] justify-between">
+          <h2 class="text-xl font-medium">{{ $t("manage.customize.preview") }}</h2>
+          <p class="text-base font-normal !text-text-secondary">{{ $t("manage.customize.previewHint") }}</p>
+        </div>
+      </div>
+      <manage-drop-preview :data="editedData" />
+    </div>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { toTypedSchema } from "@vee-validate/zod";
+import { useField, useForm } from "vee-validate";
+import * as zod from "zod";
+import type { Memo, MemoClaimPageCustomize, MemoCustomize } from "~/types/memo";
+import { formatWeb, normalizeHandle, normalizeUrl, parseUsername } from "~/utils/web";
+
+const props = defineProps<{
+  drop: Memo;
+  savedCustomize: MemoCustomize;
+  loading?: boolean;
+  updateError?: string | null;
+}>();
+const emit = defineEmits<{
+  submit: [customize: MemoClaimPageCustomize];
+}>();
+
+const { t } = useI18n();
+const claimPageCustomization = computed<MemoClaimPageCustomize>(() => {
+  const customizeData = props.savedCustomize;
+
+  return {
+    image: customizeData?.image,
+    heading: customizeData?.heading,
+    subheading: customizeData?.subheading,
+    claimText: customizeData?.claimText,
+    telegram: customizeData?.telegram,
+    instagram: customizeData?.instagram,
+    twitter: customizeData?.twitter,
+    website: customizeData?.website,
+    darkMode: customizeData?.darkMode ?? false,
+    accentColor: customizeData?.accentColor,
+  };
+});
+
+const validationSchema = toTypedSchema(
+  zod.object({
+    image: zod.string().trim().optional(),
+    heading: zod
+      .string()
+      .trim()
+      .max(40, { message: t("manage.customize.headingTooLong") })
+      .optional(),
+    subheading: zod
+      .string()
+      .trim()
+      .max(300, { message: t("manage.customize.subheadingTooLong") })
+      .optional(),
+    claimText: zod
+      .string()
+      .trim()
+      .max(40, { message: t("manage.customize.claimTextTooLong") })
+      .optional(),
+    telegram: zod.preprocess(
+      normalizeHandle,
+      zod
+        .string()
+        .refine((val) => !val || /^[a-zA-Z0-9_]{5,32}$/.test(val), {
+          message: t("manage.customize.invalidTelegram"),
+        })
+        .optional(),
+    ),
+    instagram: zod.preprocess(
+      normalizeHandle,
+      zod
+        .string()
+        .refine((val) => !val || /^[a-zA-Z0-9._]{1,30}$/.test(val), {
+          message: t("manage.customize.invalidInstagram"),
+        })
+        .optional(),
+    ),
+    twitter: zod.preprocess(
+      normalizeHandle,
+      zod
+        .string()
+        .refine((val) => !val || /^[a-zA-Z0-9_]{4,15}$/.test(val), {
+          message: t("manage.customize.invalidTwitter"),
+        })
+        .optional(),
+    ),
+    website: zod.preprocess(
+      (val) => (typeof val === "string" ? normalizeUrl(val) : ""),
+      zod
+        .string()
+        .url({ message: t("manage.customize.invalidUrl") })
+        .optional()
+        .or(zod.literal("")),
+    ),
+    darkMode: zod.boolean(),
+    accentColor: zod
+      .string()
+      .trim()
+      .regex(/^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/, {
+        message: t("manage.customize.invalidHexColor"),
+      })
+      .optional(),
+  }),
+);
+
+function getFormValues(customize: MemoClaimPageCustomize) {
+  return {
+    image: customize.image ?? undefined,
+    heading: customize.heading ?? "",
+    subheading: customize.subheading ?? "",
+    claimText: customize.claimText ?? "",
+    telegram: customize.telegram ?? "",
+    instagram: customize.instagram ?? "",
+    twitter: customize.twitter ?? "",
+    website: customize.website ? formatWeb(customize.website) : "",
+    darkMode: customize.darkMode ?? false,
+    accentColor: customize.accentColor ?? "#4ADE80",
+  };
+}
+
+const { errors, meta, resetForm } = useForm({
+  validationSchema,
+  initialValues: getFormValues(claimPageCustomization.value),
+});
+
+const claimPageCustomizationKey = computed(() => JSON.stringify(getFormValues(claimPageCustomization.value)));
+
+const { value: heading } = useField<string>("heading");
+const { value: subheading } = useField<string>("subheading");
+const { value: claimText } = useField<string>("claimText");
+const { value: telegram } = useField<string>("telegram");
+const { value: instagram } = useField<string>("instagram");
+const { value: twitter } = useField<string>("twitter");
+const { value: website } = useField<string>("website");
+const { value: darkMode } = useField<boolean>("darkMode");
+const { value: accentColor } = useField<string>("accentColor");
+
+const {
+  image,
+  imageError,
+  isCustomImage: isCustomPreview,
+  customImageFile,
+  uploaderPreviewSrc,
+  submitImageError,
+  resetImageState,
+  markSubmitAttempted,
+} = useCustomizeImageUpload({
+  initialImage: claimPageCustomization.value.image,
+  requiredMessage: t("manage.customize.customPreviewImageRequired"),
+  tooLargeMessage: t("manage.customize.customPreviewImageTooLarge"),
+  processingFailedMessage: t("manage.customize.customPreviewImageProcessingFailed"),
+  errorLogLabel: "custom image",
+});
+
+const buildClaimPageCustomize = (): MemoClaimPageCustomize => ({
+  image: isCustomPreview.value ? image.value || undefined : undefined,
+  heading: heading.value || undefined,
+  subheading: subheading.value || undefined,
+  claimText: claimText.value || undefined,
+  telegram: parseUsername(telegram.value) || undefined,
+  instagram: parseUsername(instagram.value) || undefined,
+  twitter: parseUsername(twitter.value) || undefined,
+  website: normalizeUrl(website.value) || undefined,
+  darkMode: darkMode.value,
+  accentColor: accentColor.value || undefined,
+});
+
+const editedData = computed<Memo>(() => {
+  return {
+    ...props.drop,
+    customize: {
+      ...props.savedCustomize,
+      ...buildClaimPageCustomize(),
+      success: props.savedCustomize.success,
+    },
+  };
+});
+
+const buttonLabel = computed(() => {
+  if (props.loading) {
+    return t("common.saving");
+  }
+  return t("common.saveChanges");
+});
+
+const save = () => {
+  markSubmitAttempted();
+
+  if (!meta.value.valid || imageError.value || submitImageError.value) {
+    return;
+  }
+
+  emit("submit", buildClaimPageCustomize());
+};
+
+watch(claimPageCustomizationKey, () => {
+  const nextClaimPageCustomization = claimPageCustomization.value;
+
+  resetForm({
+    values: getFormValues(nextClaimPageCustomization),
+  });
+  resetImageState(nextClaimPageCustomization.image);
+});
+</script>

--- a/app/components/manage/drop-customize-layout.vue
+++ b/app/components/manage/drop-customize-layout.vue
@@ -1,0 +1,46 @@
+<template>
+  <div class="grid grid-cols-1 gap-x-8 md:grid-cols-3">
+    <div class="flex w-full flex-col justify-center gap-8 md:w-auto">
+      <slot name="form" />
+
+      <div class="flex w-full flex-col items-center gap-2">
+        <dot-button :disabled="disabled" class="w-full" @click="$emit('save')">
+          {{ buttonLabel }}
+        </dot-button>
+        <p v-if="updateError" class="text-center text-sm !text-red-500">{{ updateError }}</p>
+        <p v-else-if="submitImageError" class="text-center text-sm !text-yellow-500">
+          {{ submitImageError }}
+        </p>
+        <p v-else-if="!isValid" class="text-center text-sm !text-yellow-500">
+          {{ $t("manage.customize.validationRequired") }}
+        </p>
+      </div>
+    </div>
+
+    <div class="col-span-2 flex flex-col gap-8">
+      <div class="flex flex-col items-center gap-4">
+        <div class="flex w-[450px] justify-between">
+          <h2 class="text-xl font-medium">{{ previewTitle }}</h2>
+          <p class="text-base font-normal !text-text-secondary">{{ previewHint }}</p>
+        </div>
+      </div>
+      <slot name="preview" />
+    </div>
+  </div>
+</template>
+
+<script lang="ts" setup>
+defineProps<{
+  buttonLabel: string;
+  disabled?: boolean;
+  isValid?: boolean;
+  updateError?: string | null;
+  submitImageError?: string | null;
+  previewTitle: string;
+  previewHint: string;
+}>();
+
+defineEmits<{
+  save: [];
+}>();
+</script>

--- a/app/components/manage/drop-customize-success-modal.vue
+++ b/app/components/manage/drop-customize-success-modal.vue
@@ -1,6 +1,15 @@
 <template>
-  <div class="grid grid-cols-1 gap-x-8 md:grid-cols-3">
-    <div class="flex w-full flex-col justify-center gap-8 md:w-auto">
+  <ManageDropCustomizeLayout
+    :button-label="buttonLabel"
+    :disabled="loading || !meta.valid || !!imageError || !!submitImageError"
+    :is-valid="meta.valid"
+    :update-error="updateError"
+    :submit-image-error="submitImageError"
+    :preview-title="$t('manage.customize.success.preview')"
+    :preview-hint="$t('manage.customize.success.previewHint')"
+    @save="save"
+  >
+    <template #form>
       <div class="flex flex-col gap-4">
         <h2 class="text-xl font-medium">{{ $t("manage.customize.success.imageTitle") }}</h2>
 
@@ -85,29 +94,9 @@
           </p>
         </div>
       </div>
+    </template>
 
-      <div class="flex w-full flex-col items-center gap-2">
-        <dot-button :disabled="loading || !meta.valid" class="w-full" @click="save">
-          {{ buttonLabel }}
-        </dot-button>
-        <p v-if="updateError" class="text-center text-sm !text-red-500">{{ updateError }}</p>
-        <p v-else-if="submitImageError" class="text-center text-sm !text-yellow-500">
-          {{ submitImageError }}
-        </p>
-        <p v-else-if="!meta.valid" class="text-center text-sm !text-yellow-500">
-          {{ $t("manage.customize.validationRequired") }}
-        </p>
-      </div>
-    </div>
-
-    <div class="col-span-2 flex flex-col gap-8">
-      <div class="flex flex-col items-center gap-4">
-        <div class="flex w-[450px] justify-between">
-          <h2 class="text-xl font-medium">{{ $t("manage.customize.success.preview") }}</h2>
-          <p class="text-base font-normal !text-text-secondary">{{ $t("manage.customize.success.previewHint") }}</p>
-        </div>
-      </div>
-
+    <template #preview>
       <div class="flex justify-center rounded-[32px] bg-black/5 p-8">
         <div class="w-full max-w-xl rounded-[28px] border border-border-default bg-surface-white p-6 shadow-2xl">
           <ClaimSuccessModalContent
@@ -121,8 +110,8 @@
           />
         </div>
       </div>
-    </div>
-  </div>
+    </template>
+  </ManageDropCustomizeLayout>
 </template>
 
 <script lang="ts" setup>

--- a/app/components/manage/drop-customize-success-modal.vue
+++ b/app/components/manage/drop-customize-success-modal.vue
@@ -1,0 +1,255 @@
+<template>
+  <div class="grid grid-cols-1 gap-x-8 md:grid-cols-3">
+    <div class="flex w-full flex-col justify-center gap-8 md:w-auto">
+      <div class="flex flex-col gap-4">
+        <h2 class="text-xl font-medium">{{ $t("manage.customize.success.imageTitle") }}</h2>
+
+        <div class="flex flex-col">
+          <div class="flex w-full items-center justify-between">
+            <b class="text-base font-normal">{{ $t("manage.customize.success.imageToggle") }}</b>
+            <dot-switch v-model="isCustomImage" />
+          </div>
+          <p class="!text-sm !font-normal !text-text-secondary">
+            {{ $t("manage.customize.success.imageHint") }}
+          </p>
+        </div>
+
+        <div v-if="isCustomImage" class="flex flex-col gap-2">
+          <dot-image-input v-model="customImageFile" :preview-src="uploaderPreviewSrc" />
+          <p v-if="imageError" class="text-sm font-normal !text-red-500">
+            {{ imageError }}
+          </p>
+          <p class="text-sm font-normal !text-text-secondary">
+            {{ $t("manage.customize.customPreviewImageRequirements") }}
+          </p>
+        </div>
+      </div>
+
+      <div class="flex flex-col gap-[42px]">
+        <h2 class="text-xl font-medium">{{ $t("manage.customize.success.title") }}</h2>
+
+        <div class="flex flex-col gap-[16px]">
+          <div class="flex w-full items-center justify-between">
+            <b class="text-base !font-normal">{{ $t("manage.customize.success.titleField") }}</b>
+            <p class="text-xs font-normal" :class="{ '!text-red-500': errors.title }">{{ title?.length ?? 0 }}/80</p>
+          </div>
+          <dot-text-input v-model="title" :placeholder="$t('claim.success')" maxlength="80" />
+          <p v-if="errors.title" class="mt-1 text-xs !text-red-500">
+            {{ errors.title }}
+          </p>
+        </div>
+
+        <div class="flex flex-col gap-[16px]">
+          <div class="flex w-full items-center justify-between">
+            <span class="flex items-center gap-2">
+              <b class="text-base !font-normal">{{ $t("manage.customize.success.descriptionField") }}</b>
+              <p class="text-xs !font-normal !text-text-secondary">({{ $t("common.optional") }})</p>
+            </span>
+            <p class="text-xs font-normal" :class="{ '!text-red-500': errors.description }">
+              {{ description?.length ?? 0 }}/300
+            </p>
+          </div>
+          <dot-text-area v-model="description" :placeholder="$t('common.text')" maxlength="300" />
+          <p v-if="errors.description" class="mt-1 text-xs !text-red-500">
+            {{ errors.description }}
+          </p>
+        </div>
+
+        <div class="flex flex-col gap-[16px]">
+          <div class="flex w-full items-center justify-between">
+            <b class="text-base !font-normal">{{ $t("manage.customize.success.shareHeadingField") }}</b>
+            <p class="text-xs font-normal" :class="{ '!text-red-500': errors.shareHeading }">
+              {{ shareHeading?.length ?? 0 }}/80
+            </p>
+          </div>
+          <dot-text-input v-model="shareHeading" :placeholder="$t('claim.wantToShare')" maxlength="80" />
+          <p v-if="errors.shareHeading" class="mt-1 text-xs !text-red-500">
+            {{ errors.shareHeading }}
+          </p>
+        </div>
+
+        <div class="flex flex-col gap-[16px]">
+          <div class="flex w-full items-center justify-between">
+            <b class="text-base !font-normal">{{ $t("manage.customize.success.primaryCtaField") }}</b>
+            <p class="text-xs font-normal" :class="{ '!text-red-500': errors.primaryCtaLabel }">
+              {{ primaryCtaLabel?.length ?? 0 }}/40
+            </p>
+          </div>
+          <dot-text-input
+            v-model="primaryCtaLabel"
+            :placeholder="$t('claim.seeInGallery', { name: drop.name || 'MEMO' })"
+            maxlength="40"
+          />
+          <p v-if="errors.primaryCtaLabel" class="mt-1 text-xs !text-red-500">
+            {{ errors.primaryCtaLabel }}
+          </p>
+        </div>
+      </div>
+
+      <div class="flex w-full flex-col items-center gap-2">
+        <dot-button :disabled="loading || !meta.valid" class="w-full" @click="save">
+          {{ buttonLabel }}
+        </dot-button>
+        <p v-if="updateError" class="text-center text-sm !text-red-500">{{ updateError }}</p>
+        <p v-else-if="submitImageError" class="text-center text-sm !text-yellow-500">
+          {{ submitImageError }}
+        </p>
+        <p v-else-if="!meta.valid" class="text-center text-sm !text-yellow-500">
+          {{ $t("manage.customize.validationRequired") }}
+        </p>
+      </div>
+    </div>
+
+    <div class="col-span-2 flex flex-col gap-8">
+      <div class="flex flex-col items-center gap-4">
+        <div class="flex w-[450px] justify-between">
+          <h2 class="text-xl font-medium">{{ $t("manage.customize.success.preview") }}</h2>
+          <p class="text-base font-normal !text-text-secondary">{{ $t("manage.customize.success.previewHint") }}</p>
+        </div>
+      </div>
+
+      <div class="flex justify-center rounded-[32px] bg-black/5 p-8">
+        <div class="w-full max-w-xl rounded-[28px] border border-border-default bg-surface-white p-6 shadow-2xl">
+          <ClaimSuccessModalContent
+            :sn="previewItemId"
+            :collection="drop.id"
+            :chain="drop.chain"
+            :memo-name="drop.name"
+            :memo-image="drop.image"
+            :customization="editedCustomization"
+            preview-mode
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { toTypedSchema } from "@vee-validate/zod";
+import { useField, useForm } from "vee-validate";
+import * as zod from "zod";
+import type { Memo, MemoCustomize, MemoSuccessModalCustomize } from "~/types/memo";
+import ClaimSuccessModalContent from "~/components/claim/ClaimSuccessModalContent.vue";
+
+const props = defineProps<{
+  drop: Memo;
+  savedCustomize: MemoCustomize;
+  loading?: boolean;
+  updateError?: string | null;
+}>();
+const emit = defineEmits<{
+  submit: [customize: MemoSuccessModalCustomize];
+}>();
+
+const { t } = useI18n();
+const successCustomization = computed(() => props.savedCustomize?.success ?? {});
+
+const validationSchema = toTypedSchema(
+  zod.object({
+    image: zod.string().trim().optional(),
+    title: zod
+      .string()
+      .trim()
+      .max(80, { message: t("manage.customize.success.titleTooLong") })
+      .optional(),
+    description: zod
+      .string()
+      .trim()
+      .max(300, { message: t("manage.customize.success.descriptionTooLong") })
+      .optional(),
+    shareHeading: zod
+      .string()
+      .trim()
+      .max(80, { message: t("manage.customize.success.shareHeadingTooLong") })
+      .optional(),
+    primaryCtaLabel: zod
+      .string()
+      .trim()
+      .max(40, { message: t("manage.customize.success.primaryCtaTooLong") })
+      .optional(),
+  }),
+);
+
+function getFormValues(customize: MemoSuccessModalCustomize) {
+  return {
+    image: customize.image ?? undefined,
+    title: customize.title ?? "",
+    description: customize.description ?? "",
+    shareHeading: customize.shareHeading ?? "",
+    primaryCtaLabel: customize.primaryCtaLabel ?? "",
+  };
+}
+
+const { errors, meta, resetForm } = useForm({
+  validationSchema,
+  initialValues: getFormValues(successCustomization.value),
+});
+
+const successCustomizationKey = computed(() => JSON.stringify(getFormValues(successCustomization.value)));
+
+const { value: title } = useField<string>("title");
+const { value: description } = useField<string>("description");
+const { value: shareHeading } = useField<string>("shareHeading");
+const { value: primaryCtaLabel } = useField<string>("primaryCtaLabel");
+
+const {
+  image,
+  imageError,
+  isCustomImage,
+  customImageFile,
+  uploaderPreviewSrc,
+  submitImageError,
+  resetImageState,
+  markSubmitAttempted,
+} = useCustomizeImageUpload({
+  initialImage: successCustomization.value.image,
+  requiredMessage: t("manage.customize.customPreviewImageRequired"),
+  tooLargeMessage: t("manage.customize.customPreviewImageTooLarge"),
+  processingFailedMessage: t("manage.customize.customPreviewImageProcessingFailed"),
+  errorLogLabel: "success modal image",
+});
+const previewItemId = "123";
+
+const buildSuccessCustomize = (): MemoSuccessModalCustomize => ({
+  image: isCustomImage.value ? image.value || undefined : undefined,
+  title: title.value || undefined,
+  description: description.value || undefined,
+  shareHeading: shareHeading.value || undefined,
+  primaryCtaLabel: primaryCtaLabel.value || undefined,
+});
+
+const editedCustomization = computed<MemoCustomize>(() => {
+  return {
+    ...props.savedCustomize,
+    success: buildSuccessCustomize(),
+  };
+});
+
+const buttonLabel = computed(() => {
+  if (props.loading) {
+    return t("common.saving");
+  }
+
+  return t("common.saveChanges");
+});
+
+const save = () => {
+  markSubmitAttempted();
+
+  if (!meta.value.valid || imageError.value || submitImageError.value) {
+    return;
+  }
+
+  emit("submit", buildSuccessCustomize());
+};
+
+watch(successCustomizationKey, () => {
+  const nextSuccessCustomization = successCustomization.value;
+
+  resetForm({
+    values: getFormValues(nextSuccessCustomization),
+  });
+  resetImageState(nextSuccessCustomization.image);
+});
+</script>

--- a/app/components/manage/drop-customize-success-modal.vue
+++ b/app/components/manage/drop-customize-success-modal.vue
@@ -213,10 +213,10 @@ const previewItemId = "123";
 
 const buildSuccessCustomize = (): MemoSuccessModalCustomize => ({
   image: isCustomImage.value ? image.value || undefined : undefined,
-  title: title.value || undefined,
-  description: description.value || undefined,
-  shareHeading: shareHeading.value || undefined,
-  primaryCtaLabel: primaryCtaLabel.value || undefined,
+  title: title.value?.trim() || undefined,
+  description: description.value?.trim() || undefined,
+  shareHeading: shareHeading.value?.trim() || undefined,
+  primaryCtaLabel: primaryCtaLabel.value?.trim() || undefined,
 });
 
 const editedCustomization = computed<MemoCustomize>(() => {

--- a/app/components/manage/drop-customize.vue
+++ b/app/components/manage/drop-customize.vue
@@ -1,178 +1,35 @@
 <template>
-  <div class="grid grid-cols-1 gap-x-8 md:grid-cols-3">
-    <!-- Customize form -->
-    <div class="flex w-full flex-col justify-center gap-8 md:w-auto">
-      <!-- Custom image -->
-      <div class="flex flex-col gap-4">
-        <span class="flex items-center gap-2">
-          <h2 class="text-xl font-medium">
-            {{ $t("manage.customize.title") }}
-          </h2>
-          <div
-            class="group relative flex h-[20px] w-[20px] cursor-default items-center justify-center rounded-full border-2 border-text-secondary px-2"
-          >
-            <span class="text-[12px] text-text-secondary">?</span>
-            <span
-              class="pointer-events-none absolute bottom-5 right-0 z-50 mt-2 w-64 rounded-lg border border-border-default bg-surface-card px-3 py-2 opacity-0 shadow-xl transition-opacity group-hover:opacity-100 dark:bg-white"
-            >
-              {{ $t("manage.customize.titleHint") }}
-            </span>
-          </div>
-        </span>
+  <div class="flex flex-col gap-8">
+    <dot-tabs v-model="selectedSection" :options="customizeSections" />
 
-        <div class="flex flex-col">
-          <div class="flex w-full items-center justify-between">
-            <b class="text-base font-normal">{{ $t("manage.customize.customPreviewImage") }}</b>
-            <dot-switch v-model="isCustomPreview" />
-          </div>
-          <p class="!text-sm !font-normal !text-text-secondary">
-            {{ $t("manage.customize.customPreviewImageHint") }}
-          </p>
-        </div>
-        <div v-if="isCustomPreview" class="flex flex-col gap-2">
-          <dot-image-input v-model="customImageFile" :preview-src="uploaderPreviewSrc" />
-          <p v-if="imageError" class="text-sm font-normal !text-red-500">
-            {{ imageError }}
-          </p>
-          <p class="text-sm font-normal !text-text-secondary">
-            {{ $t("manage.customize.customPreviewImageRequirements") }}
-          </p>
-        </div>
-      </div>
-      <!-- Text content -->
-      <div class="flex flex-col gap-[42px]">
-        <h2 class="text-xl font-medium">{{ $t("manage.customize.textContent") }}</h2>
-        <div class="flex flex-col gap-[16px]">
-          <div class="flex w-full items-center justify-between">
-            <b class="text-base !font-normal">{{ $t("manage.customize.heading") }}</b>
-            <p class="text-xs font-normal" :class="{ '!text-red-500': errors.heading }">
-              {{ heading?.length ?? 0 }}/40
-            </p>
-          </div>
-          <dot-text-input v-model="heading" :placeholder="$t('common.text')" maxlength="40" />
-          <p v-if="errors.heading" class="mt-1 text-xs !text-red-500">
-            {{ errors.heading }}
-          </p>
-        </div>
-        <div class="flex flex-col gap-[16px]">
-          <div class="flex w-full items-center justify-between">
-            <span class="flex items-center gap-2">
-              <b class="text-base !font-normal">{{ $t("manage.customize.subheading") }}</b>
-              <p class="text-xs !font-normal !text-text-secondary">({{ $t("common.optional") }})</p>
-            </span>
-            <p class="text-xs font-normal" :class="{ '!text-red-500': errors.subheading }">
-              {{ subheading?.length ?? 0 }}/300
-            </p>
-          </div>
-          <dot-text-area v-model="subheading" :placeholder="$t('common.text')" maxlength="300" />
-          <p v-if="errors.subheading" class="mt-1 text-xs !text-red-500">
-            {{ errors.subheading }}
-          </p>
-        </div>
-        <div class="flex flex-col gap-[16px]">
-          <div class="flex w-full items-center justify-between">
-            <b class="text-base !font-normal">{{ $t("manage.customize.buttonText") }}</b>
-            <p class="text-xs font-normal" :class="{ '!text-red-500': errors.claimText }">
-              {{ claimText?.length ?? 0 }}/40
-            </p>
-          </div>
-          <dot-text-input v-model="claimText" :placeholder="$t('common.claim')" maxlength="40" />
-          <p v-if="errors.claimText" class="mt-1 text-xs !text-red-500">
-            {{ errors.claimText }}
-          </p>
-        </div>
-      </div>
-      <!-- Socials -->
-      <div class="flex flex-col gap-4">
-        <h2 class="text-xl font-medium">{{ $t("manage.customize.socials") }}</h2>
-        <p class="!text-text-secondary">{{ $t("manage.customize.socialsHint") }}</p>
-        <dot-text-input v-model="telegram" placeholder="Telegram">
-          <template #prefix>
-            <Icon name="mdi:telegram" class="text-text-primary" />
-          </template>
-        </dot-text-input>
-        <p v-if="errors.telegram" class="mt-1 text-xs !text-red-500">
-          {{ errors.telegram }}
-        </p>
-        <dot-text-input v-model="instagram" placeholder="@instagram">
-          <template #prefix>
-            <Icon name="mdi:instagram" class="text-text-primary" />
-          </template>
-        </dot-text-input>
-        <p v-if="errors.instagram" class="mt-1 text-xs !text-red-500">
-          {{ errors.instagram }}
-        </p>
-        <dot-text-input v-model="twitter" placeholder="@x">
-          <template #prefix>
-            <Icon name="simple-icons:x" class="text-text-primary" />
-          </template>
-        </dot-text-input>
-        <p v-if="errors.twitter" class="mt-1 text-xs !text-red-500">
-          {{ errors.twitter }}
-        </p>
-        <dot-text-input v-model="website" placeholder="website.com">
-          <template #prefix>
-            <Icon name="mdi:web" class="text-text-primary" />
-          </template>
-        </dot-text-input>
-        <p v-if="errors.website" class="mt-1 text-xs !text-red-500">
-          {{ errors.website }}
-        </p>
-      </div>
-      <!-- Colors -->
-      <div class="flex flex-col gap-4">
-        <h2 class="text-xl font-medium">{{ $t("manage.customize.colors") }}</h2>
-        <p class="!text-text-secondary">{{ $t("manage.customize.colorsHint") }}</p>
+    <manage-drop-customize-claim-page
+      v-show="selectedSection === 'claim-page'"
+      :drop="drop"
+      :saved-customize="savedCustomize"
+      :loading="loading"
+      :update-error="updateError"
+      @submit="saveClaimPage"
+    />
 
-        <div class="flex w-full items-center justify-between">
-          <b class="text-base font-normal">{{ $t("manage.customize.darkMode") }}</b>
-          <dot-switch v-model="darkMode" />
-        </div>
-        <div class="flex flex-col gap-1">
-          <b class="text-base font-normal">{{ $t("manage.customize.accentColor") }}</b>
-          <dot-color-picker v-model="accentColor" />
-          <p v-if="errors.accentColor" class="mt-1 text-xs !text-red-500">
-            {{ errors.accentColor }}
-          </p>
-        </div>
-        <div class="flex justify-between">
-          <b class="text-base font-normal !text-text-secondary">{{ $t("manage.customize.contrastCheck") }}</b>
-          <b class="text-base font-normal !text-text-secondary">21:1</b>
-        </div>
-      </div>
-      <div class="flex w-full flex-col items-center gap-2">
-        <dot-button :disabled="loading || !meta.valid" class="w-full" @click="save">
-          {{ buttonLabel }}
-        </dot-button>
-        <p v-if="updateError" class="text-center text-sm !text-red-500">{{ updateError }}</p>
-        <p v-else-if="submitImageError" class="text-center text-sm !text-yellow-500">
-          {{ submitImageError }}
-        </p>
-        <p v-else-if="!meta.valid" class="text-center text-sm !text-yellow-500">
-          {{ $t("manage.customize.validationRequired") }}
-        </p>
-      </div>
-    </div>
-    <!-- Customize preview -->
-    <div class="col-span-2 flex flex-col gap-8">
-      <div class="flex flex-col items-center gap-4">
-        <div class="flex w-[450px] justify-between">
-          <h2 class="text-xl font-medium">{{ $t("manage.customize.preview") }}</h2>
-          <p class="text-base font-normal !text-text-secondary">{{ $t("manage.customize.previewHint") }}</p>
-        </div>
-      </div>
-      <manage-drop-preview :data="editedData" />
-    </div>
+    <manage-drop-customize-success-modal
+      v-show="selectedSection === 'success-modal'"
+      :drop="drop"
+      :saved-customize="savedCustomize"
+      :loading="loading"
+      :update-error="updateError"
+      @submit="saveSuccessModal"
+    />
   </div>
 </template>
 
 <script lang="ts" setup>
-import { toTypedSchema } from "@vee-validate/zod";
-import { useForm, useField } from "vee-validate";
-import * as zod from "zod";
-import type { Memo, MemoCustomize } from "~/types/memo";
-import { readFileAsDataUrl } from "~/utils/file";
-import { normalizeUrl } from "~/utils/web";
+import type { Memo, MemoClaimPageCustomize, MemoCustomize, MemoSuccessModalCustomize } from "~/types/memo";
+import { normalizeUrl, parseUsername } from "~/utils/web";
+
+const TELEGRAM_USERNAME_PATTERN = /^[a-zA-Z0-9_]{5,32}$/;
+const INSTAGRAM_USERNAME_PATTERN = /^[a-zA-Z0-9._]{1,30}$/;
+const TWITTER_USERNAME_PATTERN = /^[a-zA-Z0-9_]{4,15}$/;
+const HEX_COLOR_PATTERN = /^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/;
 
 const props = defineProps<{
   drop: Memo;
@@ -180,215 +37,85 @@ const props = defineProps<{
 
 const { t } = useI18n();
 
-const validationSchema = toTypedSchema(
-  zod.object({
-    image: zod.string().trim().optional(),
-    heading: zod
-      .string()
-      .trim()
-      .max(40, { message: t("manage.customize.headingTooLong") })
-      .optional(),
-    subheading: zod
-      .string()
-      .trim()
-      .max(300, { message: t("manage.customize.subheadingTooLong") })
-      .optional(),
-    claimText: zod
-      .string()
-      .trim()
-      .max(40, { message: t("manage.customize.claimTextTooLong") })
-      .optional(),
-    telegram: zod.preprocess(
-      normalizeHandle,
-      zod
-        .string()
-        .refine((val) => !val || /^[a-zA-Z0-9_]{5,32}$/.test(val), {
-          message: t("manage.customize.invalidTelegram"),
-        })
-        .optional(),
-    ),
-    instagram: zod.preprocess(
-      normalizeHandle,
-      zod
-        .string()
-        .refine((val) => !val || /^[a-zA-Z0-9._]{1,30}$/.test(val), {
-          message: t("manage.customize.invalidInstagram"),
-        })
-        .optional(),
-    ),
-    twitter: zod.preprocess(
-      normalizeHandle,
-      zod
-        .string()
-        .refine((val) => !val || /^[a-zA-Z0-9_]{4,15}$/.test(val), {
-          message: t("manage.customize.invalidTwitter"),
-        })
-        .optional(),
-    ),
-    website: zod.preprocess(
-      (val) => (typeof val === "string" ? normalizeUrl(val) : ""),
-      zod
-        .string()
-        .url({ message: t("manage.customize.invalidUrl") })
-        .optional()
-        .or(zod.literal("")),
-    ),
-    darkMode: zod.boolean(),
-    accentColor: zod
-      .string()
-      .trim()
-      .regex(/^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/, {
-        message: t("manage.customize.invalidHexColor"),
-      })
-      .optional(),
-  }),
-);
+const customizeSections = [
+  { value: "claim-page", label: t("manage.customize.tabs.claimPage") },
+  { value: "success-modal", label: t("manage.customize.tabs.successModal") },
+];
 
-const { errors, meta } = useForm({
-  validationSchema,
-  initialValues: {
-    image: props.drop.customize?.image ?? undefined,
-    heading: props.drop.customize?.heading ?? "",
-    subheading: props.drop.customize?.subheading ?? "",
-    claimText: props.drop.customize?.claimText ?? "",
-    telegram: props.drop.customize?.telegram ?? "",
-    instagram: props.drop.customize?.instagram ?? "",
-    twitter: props.drop.customize?.twitter ?? "",
-    website: props.drop.customize?.website ? formatWeb(props.drop.customize.website) : "",
-    darkMode: props.drop.customize?.darkMode ?? false,
-    accentColor: props.drop.customize?.accentColor ?? "#4ADE80",
-  },
-});
+function sanitizeCustomizeForSave(customize?: MemoCustomize | null): MemoCustomize {
+  const source = customize ?? { darkMode: false };
+  const telegram = source.telegram ? parseUsername(source.telegram) : undefined;
+  const instagram = source.instagram ? parseUsername(source.instagram) : undefined;
+  const twitter = source.twitter ? parseUsername(source.twitter) : undefined;
+  const website = source.website ? normalizeUrl(source.website) : undefined;
 
-const { value: image, errorMessage: imageError, setErrors: setImageErrors } = useField<string | undefined>("image");
-const { value: heading } = useField<string>("heading");
-const { value: subheading } = useField<string>("subheading");
-const { value: claimText } = useField<string>("claimText");
-const { value: telegram } = useField<string>("telegram");
-const { value: instagram } = useField<string>("instagram");
-const { value: twitter } = useField<string>("twitter");
-const { value: website } = useField<string>("website");
-const { value: darkMode } = useField<boolean>("darkMode");
-const { value: accentColor } = useField<string>("accentColor");
-const customImageFile = ref<File>();
-const isCustomPreview = ref(Boolean(image.value));
-const attemptedSubmit = ref(false);
-const uploaderPreviewSrc = ref<string | undefined>(image.value);
-
-const MAX_CUSTOM_IMAGE_SIZE_BYTES = 1024 * 1024;
-const requiredImageError = computed(() => {
-  if (attemptedSubmit.value && isCustomPreview.value && !image.value) {
-    return t("manage.customize.customPreviewImageRequired");
-  }
-
-  return null;
-});
-const submitImageError = computed(() => {
-  return requiredImageError.value;
-});
-
-const editedData = computed<Memo>(() => {
   return {
-    ...props.drop,
-    customize: {
-      image: image.value,
-      heading: heading.value,
-      subheading: subheading.value,
-      claimText: claimText.value,
-      telegram: telegram.value,
-      instagram: instagram.value,
-      twitter: twitter.value,
-      website: website.value,
-      darkMode: darkMode.value,
-      accentColor: accentColor.value,
-    },
+    ...source,
+    telegram: telegram && TELEGRAM_USERNAME_PATTERN.test(telegram) ? telegram : undefined,
+    instagram: instagram && INSTAGRAM_USERNAME_PATTERN.test(instagram) ? instagram : undefined,
+    twitter: twitter && TWITTER_USERNAME_PATTERN.test(twitter) ? twitter : undefined,
+    website:
+      website &&
+      (() => {
+        try {
+          return new URL(website).toString();
+        } catch {
+          return undefined;
+        }
+      })(),
+    accentColor: source.accentColor && HEX_COLOR_PATTERN.test(source.accentColor) ? source.accentColor : undefined,
   };
-});
+}
 
-const buttonLabel = computed(() => {
-  if (loading.value) {
-    return t("common.saving");
-  }
-  return t("common.saveChanges");
-});
-
+const selectedSection = ref("claim-page");
 const loading = ref(false);
 const updateError = ref<string | null>(null);
+const savedCustomize = ref<MemoCustomize>(sanitizeCustomizeForSave(props.drop.customize));
 
-const save = async () => {
-  attemptedSubmit.value = true;
+watch(
+  () => props.drop.customize,
+  (customize) => {
+    savedCustomize.value = sanitizeCustomizeForSave(customize);
+  },
+);
 
-  if (!meta.value.valid || imageError.value || requiredImageError.value) {
-    return;
-  }
+watch(selectedSection, () => {
+  updateError.value = null;
+});
 
+const saveCustomization = async (customize: MemoCustomize) => {
   updateError.value = null;
   loading.value = true;
 
   try {
-    const body: MemoCustomize = {
-      image: isCustomPreview.value ? image.value || undefined : undefined,
-      heading: heading.value || undefined,
-      subheading: subheading.value || undefined,
-      claimText: claimText.value || undefined,
-      telegram: parseUsername(telegram.value) || undefined,
-      instagram: parseUsername(instagram.value) || undefined,
-      twitter: parseUsername(twitter.value) || undefined,
-      website: normalizeUrl(website.value) || undefined,
-      darkMode: darkMode.value,
-      accentColor: accentColor.value || undefined,
-    };
+    const body = sanitizeCustomizeForSave(customize);
 
     await $fetch(`/api/manage/created/${props.drop.chain}/${props.drop.id}/customization`, {
       method: "PUT",
       body,
     });
-    attemptedSubmit.value = false;
+
+    savedCustomize.value = body;
   } catch (error) {
     console.error("Error updating drop customization:", error);
-    updateError.value = "Failed to save changes. Please try again.";
+    updateError.value = t("manage.customize.saveError");
   } finally {
     loading.value = false;
   }
 };
 
-watch(isCustomPreview, (enabled) => {
-  if (enabled) {
-    setImageErrors([]);
-    return;
-  }
+const saveClaimPage = async (claimPageCustomize: MemoClaimPageCustomize) => {
+  await saveCustomization({
+    ...savedCustomize.value,
+    ...claimPageCustomize,
+    success: savedCustomize.value.success,
+  });
+};
 
-  uploaderPreviewSrc.value = undefined;
-  image.value = undefined;
-  customImageFile.value = undefined;
-  setImageErrors([]);
-  attemptedSubmit.value = false;
-});
-
-watch(customImageFile, async (file) => {
-  if (!file) {
-    return;
-  }
-
-  attemptedSubmit.value = false;
-  setImageErrors([]);
-  uploaderPreviewSrc.value = undefined;
-
-  if (file.size > MAX_CUSTOM_IMAGE_SIZE_BYTES) {
-    setImageErrors(t("manage.customize.customPreviewImageTooLarge"));
-    customImageFile.value = undefined;
-    return;
-  }
-
-  try {
-    const nextImage = await readFileAsDataUrl(file);
-    image.value = nextImage;
-    uploaderPreviewSrc.value = nextImage;
-    setImageErrors([]);
-    isCustomPreview.value = true;
-  } catch (error) {
-    console.error("Failed to read custom image:", error);
-    setImageErrors(t("manage.customize.customPreviewImageProcessingFailed"));
-  }
-});
+const saveSuccessModal = async (successCustomize: MemoSuccessModalCustomize) => {
+  await saveCustomization({
+    ...savedCustomize.value,
+    success: successCustomize,
+  });
+};
 </script>

--- a/app/components/modals/claim-success-modal.vue
+++ b/app/components/modals/claim-success-modal.vue
@@ -1,0 +1,40 @@
+<template>
+  <VueFinalModal
+    class="flex items-center justify-center px-4"
+    content-class="relative flex w-full max-w-xl flex-col gap-6 rounded-[28px] border border-border-default bg-surface-white p-6 shadow-2xl"
+    overlay-transition="vfm-fade"
+    content-transition="vfm-fade"
+  >
+    <button type="button" class="absolute right-4 top-4" @click="closeModal">
+      <Icon name="mdi:close" size="24" class="text-text-primary" />
+    </button>
+
+    <ClaimSuccessModalContent
+      :sn="sn"
+      :collection="collection"
+      :chain="chain"
+      :memo-name="memoName"
+      :memo-image="memoImage"
+      :customization="customization"
+    />
+  </VueFinalModal>
+</template>
+
+<script setup lang="ts">
+import { VueFinalModal, useVfm } from "vue-final-modal";
+import type { MemoCustomize } from "~/types/memo";
+import ClaimSuccessModalContent from "~/components/claim/ClaimSuccessModalContent.vue";
+
+defineProps<{
+  collection: string;
+  chain: string;
+  sn?: string;
+  memoName?: string;
+  memoImage?: string;
+  customization?: MemoCustomize;
+}>();
+
+const vfm = useVfm();
+
+const closeModal = () => vfm.closeAll();
+</script>

--- a/app/components/modals/claim-success-modal.vue
+++ b/app/components/modals/claim-success-modal.vue
@@ -5,7 +5,7 @@
     overlay-transition="vfm-fade"
     content-transition="vfm-fade"
   >
-    <button type="button" class="absolute right-4 top-4" @click="closeModal">
+    <button type="button" class="absolute right-4 top-4" :aria-label="$t('common.close')" @click="closeModal">
       <Icon name="mdi:close" size="24" class="text-text-primary" />
     </button>
 

--- a/app/composables/useClaimSuccessModal.ts
+++ b/app/composables/useClaimSuccessModal.ts
@@ -1,0 +1,54 @@
+import { useModal } from "vue-final-modal";
+import ClaimSuccessModal from "~/components/modals/claim-success-modal.vue";
+import type { MemoCustomize } from "~/types/memo";
+
+interface ClaimSuccessModalAttrs {
+  sn: string;
+  collection: string;
+  chain: string;
+  memoName: string;
+  memoImage: string;
+  customization?: MemoCustomize;
+}
+
+export const useClaimSuccessModal = (
+  claimedItemId: Ref<string | undefined>,
+  getAttrs: () => Omit<ClaimSuccessModalAttrs, "sn"> | undefined,
+) => {
+  const state = reactive({
+    shouldOpen: false,
+    hasOpened: false,
+  });
+
+  watch(claimedItemId, (itemId) => {
+    const attrs = getAttrs();
+
+    if (!itemId || !attrs || !state.shouldOpen || state.hasOpened) {
+      return;
+    }
+
+    state.hasOpened = true;
+    state.shouldOpen = false;
+
+    const { open: openSuccessModal } = useModal({
+      component: ClaimSuccessModal,
+      attrs: {
+        sn: itemId,
+        ...attrs,
+      },
+    });
+
+    openSuccessModal();
+  });
+
+  const arm = () => {
+    state.shouldOpen = true;
+    state.hasOpened = false;
+  };
+
+  const disarm = () => {
+    state.shouldOpen = false;
+  };
+
+  return { arm, disarm };
+};

--- a/app/composables/useCustomizeImageUpload.ts
+++ b/app/composables/useCustomizeImageUpload.ts
@@ -1,0 +1,102 @@
+import { readFileAsDataUrl } from "~/utils/file";
+
+type UseCustomizeImageUploadOptions = {
+  initialImage?: string;
+  requiredMessage: string;
+  tooLargeMessage: string;
+  processingFailedMessage: string;
+  errorLogLabel: string;
+  maxBytes?: number;
+};
+
+export const useCustomizeImageUpload = (options: UseCustomizeImageUploadOptions) => {
+  const maxBytes = options.maxBytes ?? 1024 * 1024;
+
+  const image = ref<string | undefined>(options.initialImage);
+  const isCustomImage = ref(Boolean(options.initialImage));
+  const customImageFile = shallowRef<File>();
+  const attemptedSubmit = ref(false);
+  const uploaderPreviewSrc = ref<string | undefined>(options.initialImage);
+  const imageError = ref<string>();
+
+  const requiredImageError = computed(() => {
+    if (attemptedSubmit.value && isCustomImage.value && !image.value) {
+      return options.requiredMessage;
+    }
+
+    return null;
+  });
+
+  const submitImageError = computed(() => requiredImageError.value);
+
+  const clearImageError = () => {
+    imageError.value = undefined;
+  };
+
+  const resetImageState = (nextImage?: string) => {
+    image.value = nextImage;
+    isCustomImage.value = Boolean(nextImage);
+    customImageFile.value = undefined;
+    attemptedSubmit.value = false;
+    uploaderPreviewSrc.value = nextImage;
+    clearImageError();
+  };
+
+  const markSubmitAttempted = () => {
+    attemptedSubmit.value = true;
+  };
+
+  watch(isCustomImage, (enabled) => {
+    if (enabled) {
+      clearImageError();
+      return;
+    }
+
+    uploaderPreviewSrc.value = undefined;
+    image.value = undefined;
+    customImageFile.value = undefined;
+    attemptedSubmit.value = false;
+    clearImageError();
+  });
+
+  watch(customImageFile, async (file) => {
+    if (!file) {
+      return;
+    }
+
+    attemptedSubmit.value = false;
+    clearImageError();
+    uploaderPreviewSrc.value = undefined;
+
+    if (file.size > maxBytes) {
+      imageError.value = options.tooLargeMessage;
+      customImageFile.value = undefined;
+      return;
+    }
+
+    try {
+      const nextImage = await readFileAsDataUrl(file);
+      image.value = nextImage;
+      uploaderPreviewSrc.value = nextImage;
+      clearImageError();
+      isCustomImage.value = true;
+    } catch (error) {
+      console.error(`Failed to read ${options.errorLogLabel}:`, error);
+      imageError.value = options.processingFailedMessage;
+    }
+  });
+
+  return {
+    image,
+    imageError,
+    isCustomImage,
+    customImageFile,
+    attemptedSubmit,
+    uploaderPreviewSrc,
+    requiredImageError,
+    submitImageError,
+    clearImageError,
+    resetImageState,
+    markSubmitAttempted,
+  };
+};

--- a/app/pages/claim/[code].vue
+++ b/app/pages/claim/[code].vue
@@ -84,7 +84,6 @@
 </template>
 <script setup lang="ts">
 import QRScannerModal from "~/components/modals/qr-scanner-modal.vue";
-import ClaimSuccessModal from "~/components/modals/claim-success-modal.vue";
 import { DateTime } from "luxon";
 import { useModal } from "vue-final-modal";
 import { FetchError } from "ofetch";
@@ -258,33 +257,17 @@ const { open } = useModal({
   },
 });
 
-const successModalState = reactive({
-  shouldOpen: false,
-  hasOpened: false,
-});
-
-watch(claimedItemId, (itemId) => {
-  if (!itemId || !data.value || !successModalState.shouldOpen || successModalState.hasOpened) {
-    return;
-  }
-
-  successModalState.hasOpened = true;
-  successModalState.shouldOpen = false;
-
-  const { open: openSuccessModal } = useModal({
-    component: ClaimSuccessModal,
-    attrs: {
-      sn: itemId,
-      collection: data.value.id,
-      chain: data.value.chain,
-      memoName: data.value.name,
-      memoImage: data.value.image,
-      customization: data.value.customize,
-    },
-  });
-
-  openSuccessModal();
-});
+const { arm: armSuccessModal, disarm: disarmSuccessModal } = useClaimSuccessModal(claimedItemId, () =>
+  data.value
+    ? {
+        collection: data.value.id,
+        chain: data.value.chain,
+        memoName: data.value.name,
+        memoImage: data.value.image,
+        customization: data.value.customize,
+      }
+    : undefined,
+);
 
 const claim = async () => {
   if (!address.value) return;
@@ -296,8 +279,7 @@ const claim = async () => {
   try {
     claimFailed.value = false;
     isClaiming.value = true;
-    successModalState.shouldOpen = true;
-    successModalState.hasOpened = false;
+    armSuccessModal();
 
     const response = await $fetch("/api/claim", {
       method: "POST",
@@ -312,7 +294,7 @@ const claim = async () => {
     console.error("Claim failed:", error);
     claimFailed.value = true;
     isClaiming.value = false;
-    successModalState.shouldOpen = false;
+    disarmSuccessModal();
     if (error instanceof FetchError && error.status === 409) {
       alreadyCollected.value = true;
       return;

--- a/app/pages/claim/[code].vue
+++ b/app/pages/claim/[code].vue
@@ -26,6 +26,7 @@
         :telegram="data.customize?.telegram"
         :instagram="data.customize?.instagram"
         :website="data.customize?.website"
+        :twitter="data.customize?.twitter"
       />
 
       <!-- Interaction Section -->
@@ -70,13 +71,20 @@
           <ClaimChainBadge v-if="data.chain && !allClaimed" :chain="data.chain" />
         </template>
 
-        <ClaimSuccess :sn="claimedItemId" :collection="data.id" :chain="data.chain" :memo-name="data?.name" />
+        <ClaimSuccess
+          :sn="claimedItemId"
+          :collection="data.id"
+          :chain="data.chain"
+          :memo-name="data?.name"
+          :customization="data.customize"
+        />
       </div>
     </template>
   </ClaimLayout>
 </template>
 <script setup lang="ts">
 import QRScannerModal from "~/components/modals/qr-scanner-modal.vue";
+import ClaimSuccessModal from "~/components/modals/claim-success-modal.vue";
 import { DateTime } from "luxon";
 import { useModal } from "vue-final-modal";
 import { FetchError } from "ofetch";
@@ -250,6 +258,34 @@ const { open } = useModal({
   },
 });
 
+const successModalState = reactive({
+  shouldOpen: false,
+  hasOpened: false,
+});
+
+watch(claimedItemId, (itemId) => {
+  if (!itemId || !data.value || !successModalState.shouldOpen || successModalState.hasOpened) {
+    return;
+  }
+
+  successModalState.hasOpened = true;
+  successModalState.shouldOpen = false;
+
+  const { open: openSuccessModal } = useModal({
+    component: ClaimSuccessModal,
+    attrs: {
+      sn: itemId,
+      collection: data.value.id,
+      chain: data.value.chain,
+      memoName: data.value.name,
+      memoImage: data.value.image,
+      customization: data.value.customize,
+    },
+  });
+
+  openSuccessModal();
+});
+
 const claim = async () => {
   if (!address.value) return;
   if (!canClaim.value) return;
@@ -260,6 +296,8 @@ const claim = async () => {
   try {
     claimFailed.value = false;
     isClaiming.value = true;
+    successModalState.shouldOpen = true;
+    successModalState.hasOpened = false;
 
     const response = await $fetch("/api/claim", {
       method: "POST",
@@ -274,6 +312,7 @@ const claim = async () => {
     console.error("Claim failed:", error);
     claimFailed.value = true;
     isClaiming.value = false;
+    successModalState.shouldOpen = false;
     if (error instanceof FetchError && error.status === 409) {
       alreadyCollected.value = true;
       return;

--- a/app/pages/claim/email/[token].vue
+++ b/app/pages/claim/email/[token].vue
@@ -98,10 +98,8 @@
 <script setup lang="ts">
 import { FetchError } from "ofetch";
 import type { Prefix } from "@kodadot1/static";
-import { useModal } from "vue-final-modal";
 import type { FinalizeClaimResponse } from "~/types/email-auth";
 import { DateTime } from "luxon";
-import ClaimSuccessModal from "~/components/modals/claim-success-modal.vue";
 import { formatTimeRemaining } from "~/utils/time";
 
 const route = useRoute();
@@ -135,33 +133,17 @@ const reservationExpiresAt = computed(() => {
   return DateTime.fromISO(data.value.expiresAt).toLocaleString(DateTime.DATETIME_MED);
 });
 
-const successModalState = reactive({
-  shouldOpen: false,
-  hasOpened: false,
-});
-
-watch(claimedItemId, (itemId) => {
-  if (!itemId || !data.value || !successModalState.shouldOpen || successModalState.hasOpened) {
-    return;
-  }
-
-  successModalState.hasOpened = true;
-  successModalState.shouldOpen = false;
-
-  const { open: openSuccessModal } = useModal({
-    component: ClaimSuccessModal,
-    attrs: {
-      sn: itemId,
-      collection: data.value.collectionId,
-      chain: data.value.chain,
-      memoName: data.value.memoName,
-      memoImage: data.value.memoImage,
-      customization: data.value.customize,
-    },
-  });
-
-  openSuccessModal();
-});
+const { arm: armSuccessModal, disarm: disarmSuccessModal } = useClaimSuccessModal(claimedItemId, () =>
+  data.value
+    ? {
+        collection: data.value.collectionId,
+        chain: data.value.chain,
+        memoName: data.value.memoName,
+        memoImage: data.value.memoImage,
+        customization: data.value.customize,
+      }
+    : undefined,
+);
 
 const finalizeClaim = async () => {
   if (!address.value || !canClaim.value) return;
@@ -169,8 +151,7 @@ const finalizeClaim = async () => {
   try {
     claimFailed.value = false;
     isClaiming.value = true;
-    successModalState.shouldOpen = true;
-    successModalState.hasOpened = false;
+    armSuccessModal();
 
     const response = await $fetch<FinalizeClaimResponse>(`/api/email-claim/${token.value}/finalize`, {
       method: "POST",
@@ -182,7 +163,7 @@ const finalizeClaim = async () => {
     console.error("Claim failed:", err);
     claimFailed.value = true;
     isClaiming.value = false;
-    successModalState.shouldOpen = false;
+    disarmSuccessModal();
     if (err instanceof FetchError && err.status === 409) {
       alreadyCollected.value = true;
     }

--- a/app/pages/claim/email/[token].vue
+++ b/app/pages/claim/email/[token].vue
@@ -44,6 +44,7 @@
         :telegram="data.customize?.telegram"
         :instagram="data.customize?.instagram"
         :website="data.customize?.website"
+        :twitter="data.customize?.twitter"
       />
 
       <div class="flex w-full flex-col space-y-[16px] self-stretch">
@@ -87,6 +88,7 @@
           :collection="data.collectionId"
           :chain="data.chain"
           :memo-name="data.memoName"
+          :customization="data.customize"
         />
       </div>
     </template>
@@ -96,8 +98,10 @@
 <script setup lang="ts">
 import { FetchError } from "ofetch";
 import type { Prefix } from "@kodadot1/static";
+import { useModal } from "vue-final-modal";
 import type { FinalizeClaimResponse } from "~/types/email-auth";
 import { DateTime } from "luxon";
+import ClaimSuccessModal from "~/components/modals/claim-success-modal.vue";
 import { formatTimeRemaining } from "~/utils/time";
 
 const route = useRoute();
@@ -131,12 +135,42 @@ const reservationExpiresAt = computed(() => {
   return DateTime.fromISO(data.value.expiresAt).toLocaleString(DateTime.DATETIME_MED);
 });
 
+const successModalState = reactive({
+  shouldOpen: false,
+  hasOpened: false,
+});
+
+watch(claimedItemId, (itemId) => {
+  if (!itemId || !data.value || !successModalState.shouldOpen || successModalState.hasOpened) {
+    return;
+  }
+
+  successModalState.hasOpened = true;
+  successModalState.shouldOpen = false;
+
+  const { open: openSuccessModal } = useModal({
+    component: ClaimSuccessModal,
+    attrs: {
+      sn: itemId,
+      collection: data.value.collectionId,
+      chain: data.value.chain,
+      memoName: data.value.memoName,
+      memoImage: data.value.memoImage,
+      customization: data.value.customize,
+    },
+  });
+
+  openSuccessModal();
+});
+
 const finalizeClaim = async () => {
   if (!address.value || !canClaim.value) return;
 
   try {
     claimFailed.value = false;
     isClaiming.value = true;
+    successModalState.shouldOpen = true;
+    successModalState.hasOpened = false;
 
     const response = await $fetch<FinalizeClaimResponse>(`/api/email-claim/${token.value}/finalize`, {
       method: "POST",
@@ -148,6 +182,7 @@ const finalizeClaim = async () => {
     console.error("Claim failed:", err);
     claimFailed.value = true;
     isClaiming.value = false;
+    successModalState.shouldOpen = false;
     if (err instanceof FetchError && err.status === 409) {
       alreadyCollected.value = true;
     }

--- a/app/types/memo.ts
+++ b/app/types/memo.ts
@@ -6,7 +6,7 @@ export const SECURITY_MODES = ["static", "dynamic"] as const;
 export type SecurityMode = (typeof SECURITY_MODES)[number];
 
 export const MAX_DYNAMIC_MEMO_SUPPLY = 1000;
-export type MemoCustomize = {
+export type MemoClaimPageCustomize = {
   image?: string;
   heading?: string;
   subheading?: string;
@@ -17,6 +17,18 @@ export type MemoCustomize = {
   website?: string;
   darkMode?: boolean;
   accentColor?: string;
+};
+
+export type MemoSuccessModalCustomize = {
+  image?: string;
+  title?: string;
+  description?: string;
+  shareHeading?: string;
+  primaryCtaLabel?: string;
+};
+
+export type MemoCustomize = MemoClaimPageCustomize & {
+  success?: MemoSuccessModalCustomize;
 };
 
 export type Memo = {

--- a/i18n/locales/en-US.json
+++ b/i18n/locales/en-US.json
@@ -422,6 +422,10 @@
       }
     },
     "customize": {
+      "tabs": {
+        "claimPage": "Claim page",
+        "successModal": "Success modal"
+      },
       "title": "Claim page image",
       "titleHint": "This image will be shown on the claim page. After claiming, users will receive your memo NFT with its own unique image.",
       "customPreviewImage": "Use custom preview image",
@@ -447,11 +451,28 @@
       "subheadingTooLong": "Subheading must be 300 characters or less",
       "claimTextTooLong": "Button text must be 40 characters or less",
       "validationRequired": "Please fix validation errors before saving",
+      "saveError": "Failed to save changes. Please try again.",
       "invalidTelegram": "Telegram username must be 5-32 characters: letters, digits, or underscores",
       "invalidInstagram": "Instagram username must be 1-30 characters: letters, digits, underscores, or periods",
       "invalidTwitter": "Twitter/X username must be 4-15 characters: letters, digits, or underscores",
       "invalidUrl": "Please enter a valid URL",
-      "invalidHexColor": "Please enter a valid hex color (e.g., #FF5500)"
+      "invalidHexColor": "Please enter a valid hex color (e.g., #FF5500)",
+      "success": {
+        "imageTitle": "Image",
+        "imageHint": "Upload a different image for the success modal",
+        "imageToggle": "Use custom image",
+        "title": "Text Content",
+        "titleField": "Title",
+        "descriptionField": "Description",
+        "shareHeadingField": "Share heading",
+        "primaryCtaField": "Button Text",
+        "preview": "Preview",
+        "previewHint": "Live preview of the success modal",
+        "titleTooLong": "Title must be 80 characters or less",
+        "descriptionTooLong": "Description must be 300 characters or less",
+        "shareHeadingTooLong": "Share heading must be 80 characters or less",
+        "primaryCtaTooLong": "Button label must be 40 characters or less"
+      }
     },
     "settings": {
       "title": "Distribution settings",

--- a/i18n/locales/en-US.json
+++ b/i18n/locales/en-US.json
@@ -30,7 +30,8 @@
     "saving": "Saving...",
     "sending": "Sending...",
     "checking": "Checking...",
-    "remove": "Remove"
+    "remove": "Remove",
+    "close": "Close"
   },
   "landing": {
     "quote1": "Your memories,",


### PR DESCRIPTION

<img width="2600" height="1792" alt="CleanShot 2026-04-15 at 19 09 59@2x" src="https://github.com/user-attachments/assets/d6ebed2c-87e5-457f-9f27-0b0981f2b847" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Success confirmation modal appears after claiming, with customizable title, description, share heading, and CTA text.
  * Tabbed customization UI separating claim page and success modal settings.
  * Image upload with live preview and validation feedback for both claim page and success modal.
  * Twitter social link support added.
  * Share buttons improved (accessibility/disabled behavior in preview) and modal preview available before saving.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->