### PR TITLE
ref: use original mint image in manage views

### DIFF
--- a/app/components/manage/drop-card.vue
+++ b/app/components/manage/drop-card.vue
@@ -106,7 +106,7 @@ const props = defineProps<{
 
 const { locale } = useI18n();
 
-const imageSrc = computed(() => props.drop.customize?.image || props.drop.image);
+const imageSrc = computed(() => props.drop.image);
 
 // Starts in
 const startsIn = computed<string | null>(() => {

--- a/app/components/manage/drop-detail.vue
+++ b/app/components/manage/drop-detail.vue
@@ -138,7 +138,7 @@ const isExpired = computed<boolean>(() => {
   return date.diff(now, ["seconds"]).as("seconds") < 0;
 });
 
-const imageSrc = computed(() => props.drop.customize.image || props.drop.image);
+const imageSrc = computed(() => props.drop.image);
 
 const remainingTime = computed<string>(() => {
   if (isExpired.value) {


### PR DESCRIPTION
## Summary
- Updated manage drop card and detail views to always render the original mint image.
- Removed fallback to `customize.image` in manage views so the displayed asset matches the source mint image.

## Testing
- Not run.
- Verified the change is limited to `app/components/manage/drop-card.vue` and `app/components/manage/drop-detail.vue`.
- Confirmed both components now resolve `imageSrc` from `props.drop.image` only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed image display inconsistencies in drop management components to ensure consistent rendering behavior across card and detail views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


<img width="3220" height="2012" alt="CleanShot 2026-04-27 at 12 29 52@2x" src="https://github.com/user-attachments/assets/d347f64d-4b55-4502-8ed3-fb7180157c91" />
