### PR TITLE
fix(manage): localize hourly analytics chart to viewer timezone

### DIFF
--- a/app/components/analytics/Charts.vue
+++ b/app/components/analytics/Charts.vue
@@ -129,16 +129,21 @@ const trendChartData = computed(() => ({
 
 const hourlyChartData = computed(() => {
   const hours = Array.from({ length: 24 }, (_, i) => i);
-  const claimsByHour = hours.map((hour) => {
-    const found = props.distributionData.find((d) => d.hour === hour);
-    return found?.claims ?? 0;
+  const claimsByLocalHour = Array.from({ length: 24 }, () => 0);
+  const timezoneOffsetMinutes = new Date().getTimezoneOffset();
+
+  props.distributionData.forEach(({ hour, claims }) => {
+    const localMinutes = (hour * 60 - timezoneOffsetMinutes + 24 * 60) % (24 * 60);
+    const localHour = Math.floor(localMinutes / 60);
+    claimsByLocalHour[localHour] = (claimsByLocalHour[localHour] ?? 0) + claims;
   });
+
   return {
     labels: hours.map((h) => h.toString().padStart(2, "0")),
     datasets: [
       {
         label: "Claims",
-        data: claimsByHour,
+        data: claimsByLocalHour,
         backgroundColor: chartGreen,
         borderRadius: 3,
         barThickness: 16,


### PR DESCRIPTION
## Summary
- Convert hourly analytics distribution data into the viewer's local timezone before rendering the chart.
- Aggregate claims into local-hour buckets so bars align with the user's clock instead of the source hour values.
- Keep chart labels as `00` through `23` while updating the dataset values to reflect localized counts.

## Testing
- Not run
- Reviewed the data transformation logic to confirm hour-to-local-hour conversion uses the current timezone offset
- Verified the chart still renders a 24-hour label set with localized dataset values

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed analytics charts to correctly display claims data adjusted to your local timezone. Hourly claim data is now properly bucketed and aggregated based on your system's timezone offset, ensuring accurate representation of claim timing in your local time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->