### PR TITLE
ref: change address display ss58 to prefix 0

### DIFF
--- a/app/components/analytics/ClaimsTable.vue
+++ b/app/components/analytics/ClaimsTable.vue
@@ -52,9 +52,9 @@
               <NuxtLink
                 :to="getProfileLink(item.currentOwner)"
                 class="inline-flex items-center gap-1 text-text-primary hover:underline"
-                :title="item.currentOwner"
+                :title="displayAddress(item.currentOwner)"
               >
-                {{ shortenAddress(item.currentOwner) }}
+                {{ displayAddressShortener(item.currentOwner) }}
                 <Icon name="mdi:arrow-top-right" class="size-[14px]" />
               </NuxtLink>
             </td>
@@ -96,7 +96,7 @@ import type { Prefix } from "@kodadot1/static";
 import { DateTime, Duration } from "luxon";
 import type { ClaimItem } from "./types";
 import type { Ownership } from "~/types/memo";
-import { formatAddressByPrefix } from "~/utils/account";
+import { displayAddress, displayAddressShortener, formatAddressByPrefix } from "~/utils/account";
 
 const props = defineProps<{
   claims: ClaimItem[];
@@ -115,11 +115,6 @@ defineEmits<{
 }>();
 
 const { t, locale } = useI18n();
-
-const shortenAddress = (address: string): string => {
-  if (address.length <= 12) return address;
-  return `${address.slice(0, 6)}...${address.slice(-4)}`;
-};
 
 const getProfileLink = (address: string): string => `/${props.chain}/u/${formatAddressByPrefix(address, props.chain)}`;
 

--- a/app/components/claim/ClaimTypeContent.vue
+++ b/app/components/claim/ClaimTypeContent.vue
@@ -77,7 +77,7 @@
 
         <dot-text-input
           v-if="usePreviousAddress"
-          :model-value="previousWalletAddress"
+          :model-value="previousWalletDisplayAddress"
           :placeholder="t('common.address')"
           disabled
           class="opacity-60"
@@ -114,9 +114,14 @@ const usePreviousAddress = defineModel<boolean>("usePreviousAddress", { default:
 
 const emailFormRef = ref<HTMLFormElement | null>(null);
 
+const previousWalletDisplayAddress = computed(() => {
+  if (!props.previousWalletAddress) return "";
+  return displayAddress(props.previousWalletAddress);
+});
+
 const truncatedAddress = computed(() => {
   if (!props.previousWalletAddress) return "";
-  return addressShortener(props.previousWalletAddress, 6, -6);
+  return displayAddressShortener(props.previousWalletAddress, 6, -6);
 });
 
 const validateEmail = () => {

--- a/app/components/manage/drop-detail.vue
+++ b/app/components/manage/drop-detail.vue
@@ -45,7 +45,7 @@
         <p class="text-[14px] !text-[#606060]">
           by:
           <span class="cursor-copy border-b border-dotted border-black" @click="owner ? clipboard.copy(owner) : null">
-            {{ owner ? addressShortener(owner) : "" }}
+            {{ owner ? displayAddressShortener(owner) : "" }}
           </span>
         </p>
         <span class="hidden items-center gap-2 md:flex">

--- a/app/components/manage/drop-organizers.vue
+++ b/app/components/manage/drop-organizers.vue
@@ -38,8 +38,8 @@
         class="group flex items-center justify-between rounded-xl border border-border-default bg-surface-card px-4 py-3"
       >
         <div class="flex flex-col gap-1">
-          <span class="font-mono text-sm text-text-primary" :title="organizer.address">
-            {{ shortenAddress(organizer.address) }}
+          <span class="font-mono text-sm text-text-primary" :title="displayAddress(organizer.address)">
+            {{ displayAddressShortener(organizer.address) }}
           </span>
           <span class="text-xs text-text-secondary">
             {{ t("manage.organizers.addedOn", { date: formatDate(organizer.createdAt) }) }}
@@ -154,11 +154,6 @@ const removeOrganizer = async (address: string) => {
   } finally {
     removingAddress.value = null;
   }
-};
-
-const shortenAddress = (address: string): string => {
-  if (address.length <= 12) return address;
-  return `${address.slice(0, 6)}...${address.slice(-4)}`;
 };
 
 const formatDate = (dateString: string): string => {

--- a/app/components/modals/connect-modal.vue
+++ b/app/components/modals/connect-modal.vue
@@ -81,7 +81,7 @@
               <div class="flex flex-1 flex-col items-start gap-1 px-4 py-3">
                 <h2 class="font-bold">{{ account.name }}</h2>
                 <p class="text-xs">
-                  {{ addressShortener(account.address, 7, -7) }}
+                  {{ displayAddressShortener(account.address, 7, -7) }}
                 </p>
               </div>
             </div>

--- a/app/pages/[chain]/u/[address].vue
+++ b/app/pages/[chain]/u/[address].vue
@@ -47,7 +47,7 @@
 
             <div class="flex flex-col items-center">
               <h1 class="text-[40px] font-bold leading-[48px] text-text-primary">{{ profile?.name || displayName }}</h1>
-              <p class="font-mono text-[16px] text-text-secondary">{{ address }}</p>
+              <p class="font-mono text-[16px] text-text-secondary">{{ displayAddressValue }}</p>
             </div>
 
             <div v-if="profile?.socials && profile.socials.length > 0" class="flex items-center gap-[12px]">
@@ -158,7 +158,6 @@ import { DateTime } from "luxon";
 import ManageDropCard from "~/components/manage/drop-card.vue";
 import type { Memo } from "~/types/memo";
 import { fetchProfileByAddress, Socials, type Profile as _Profile } from "~/services/profile";
-import { addressShortener } from "~/utils/account";
 import type { Prefix } from "@kodadot1/static";
 
 const route = useRoute();
@@ -183,7 +182,10 @@ const { data: memosData, pending: memosPending } = useAsyncData(
 const memos = computed(() => memosData.value || []);
 const profileUrl = computed(() => `${requestURL.origin}${route.fullPath}`);
 
-const displayName = computed(() => (profile.value?.name ? profile.value.name : addressShortener(address.value, 6, -4)));
+const displayAddressValue = computed(() => displayAddress(address.value));
+const displayName = computed(() =>
+  profile.value?.name ? profile.value.name : displayAddressShortener(address.value, 6, -4),
+);
 
 async function shareProfile() {
   if (!import.meta.client) return;

--- a/app/stores/account.ts
+++ b/app/stores/account.ts
@@ -49,11 +49,11 @@ export const useAccountStore = defineStore("account", {
     hasSelectedAccount: (state) => !!state.selected,
     shortAddress: (state) => {
       if (!state.selected) return "";
-      return addressShortener(state.selected.address);
+      return displayAddressShortener(state.selected.address);
     },
     midAddress: (state) => {
       if (!state.selected) return "";
-      return addressShortener(state.selected.address, 8);
+      return displayAddressShortener(state.selected.address, 8);
     },
     accountName: (state) => {
       if (!state.selected) return "";

--- a/app/utils/account.ts
+++ b/app/utils/account.ts
@@ -32,11 +32,24 @@ export const isValidSubstrateAddress = (address: string): boolean => {
   try {
     encodeAddress(decodeAddress(address));
     return true;
-  } catch (error) {
+  } catch {
     return false;
   }
 };
 
 export const addressShortener = (address: string, startOffset = 6, endOffset = -4): string => {
   return `${address.slice(0, startOffset)}...${address.slice(endOffset)}`;
+};
+
+export const displayAddress = (address: string): string => {
+  if (!address) return "";
+  try {
+    return encodeAddress(decodeAddress(address), 0);
+  } catch {
+    return address;
+  }
+};
+
+export const displayAddressShortener = (address: string, startOffset = 6, endOffset = -4): string => {
+  return addressShortener(displayAddress(address), startOffset, endOffset);
 };

--- a/app/utils/account.ts
+++ b/app/utils/account.ts
@@ -51,5 +51,7 @@ export const displayAddress = (address: string): string => {
 };
 
 export const displayAddressShortener = (address: string, startOffset = 6, endOffset = -4): string => {
-  return addressShortener(displayAddress(address), startOffset, endOffset);
+  const displayedAddress = displayAddress(address);
+  if (!displayedAddress) return "";
+  return addressShortener(displayedAddress, startOffset, endOffset);
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Consistent, shortened and full address display applied across profiles, lists, modals, and details for clearer tooltips and subtitles.
* **Bug Fixes**
  * Improved address formatting and validation with safer fallbacks for invalid or missing addresses.
* **UX**
  * Shortened addresses used in account lists and organizer/display views while full addresses appear in tooltips and titles for easier copying and readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<img width="1140" height="256" alt="CleanShot 2026-05-05 at 14 35 57@2x" src="https://github.com/user-attachments/assets/4a119403-0ccd-47b7-8402-7be7715419f7" />

<img width="3744" height="1076" alt="CleanShot 2026-05-05 at 14 35 25@2x" src="https://github.com/user-attachments/assets/cf4d3de4-5cff-4ce3-95ed-766a9c534ef9" />

